### PR TITLE
Hiddenservices pr

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -440,7 +440,7 @@ public class Peer extends PeerSocketHandler {
         PeerAddress peerAddress = getAddress();
         long peerTime = vPeerVersionMessage.time * 1000;
         log.info("Connected to {}: version={}, subVer='{}', services=0x{}, time={}, blocks={}",
-                peerAddress == null ? "Peer" : peerAddress.getAddr().getHostAddress(),
+                peerAddress == null ? "Peer" : (peerAddress.getAddr() == null ? peerAddress.getHostname() : peerAddress.getAddr().getHostAddress()),
                 peerVersion,
                 vPeerVersionMessage.subVer,
                 vPeerVersionMessage.localServices,

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -17,6 +17,13 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.net.AddressChecker;
+import org.bitcoinj.net.OnionCat;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Objects;
 import com.google.common.net.InetAddresses;
 
 import java.io.IOException;
@@ -30,11 +37,14 @@ import static org.bitcoinj.core.Utils.uint32ToByteStreamLE;
 import static org.bitcoinj.core.Utils.uint64ToByteStreamLE;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+
 /**
  * A PeerAddress holds an IP address and port number representing the network location of
  * a peer in the Bitcoin P2P network. It exists primarily for serialization purposes.
  */
 public class PeerAddress extends ChildMessage {
+    private static final Logger log = LoggerFactory.getLogger(PeerAddress.class);
+
     private static final long serialVersionUID = 7501293709324197411L;
     static final int MESSAGE_SIZE = 30;
 
@@ -102,17 +112,28 @@ public class PeerAddress extends ChildMessage {
      * InetAddress or a String hostname. If you want to connect to a .onion, set the hostname to the .onion address.
      */
     public PeerAddress(InetSocketAddress addr) {
-        if (addr.getHostName() == null || !addr.getHostName().toLowerCase().endsWith(".onion")) {
+        /* socks addresses, eg Tor, use hostname only because no local lookup is performed.
+         * includes .onion hidden services.
+         */
+        String host = addr.getHostString();
+        if( host != null && host.endsWith(".onion") ) {
+            this.hostname = host;
+            try {
+                this.addr = OnionCat.onionHostToInetAddress(this.hostname);
+            }
+            catch (UnknownHostException e) {
+                log.warn( "Invalid format for onion address: {}", this.hostname );
+            }
+        }
+        else {
             this.addr = checkNotNull(addr.getAddress());
-        } else {
-            this.hostname = addr.getHostName();
         }
         this.port = addr.getPort();
         this.protocolVersion = NetworkParameters.PROTOCOL_VERSION;
         this.services = BigInteger.ZERO;
         length = protocolVersion > 31402 ? MESSAGE_SIZE : MESSAGE_SIZE - 4;
     }
-
+    
     public static PeerAddress localhost(NetworkParameters params) {
         return new PeerAddress(InetAddresses.forString("127.0.0.1"), params.getPort());
     }
@@ -127,14 +148,25 @@ public class PeerAddress extends ChildMessage {
             uint32ToByteStreamLE(secs, stream);
         }
         uint64ToByteStreamLE(services, stream);  // nServices.
-        // Java does not provide any utility to map an IPv4 address into IPv6 space, so we have to do it by hand.
-        byte[] ipBytes = addr.getAddress();
-        if (ipBytes.length == 4) {
-            byte[] v6addr = new byte[16];
-            System.arraycopy(ipBytes, 0, v6addr, 12, 4);
-            v6addr[10] = (byte) 0xFF;
-            v6addr[11] = (byte) 0xFF;
-            ipBytes = v6addr;
+
+        AddressChecker addrChecker = new AddressChecker();
+        byte[] ipBytes;
+        if( addrChecker.IsOnionCatTor( addr ) ) {
+            ipBytes = OnionCat.onionHostToIPV6Bytes( hostname );
+        }
+        else if( addr != null ) {
+            // Java does not provide any utility to map an IPv4 address into IPv6 space, so we have to do it by hand.
+            ipBytes = addr.getAddress();
+            if (ipBytes.length == 4) {
+                byte[] v6addr = new byte[16];
+                System.arraycopy(ipBytes, 0, v6addr, 12, 4);
+                v6addr[10] = (byte) 0xFF;
+                v6addr[11] = (byte) 0xFF;
+                ipBytes = v6addr;
+            }
+        }
+        else {
+            ipBytes = new byte[16];  // zero-filled.
         }
         stream.write(ipBytes);
         // And write out the port. Unlike the rest of the protocol, address and port is in big endian byte order.
@@ -160,8 +192,13 @@ public class PeerAddress extends ChildMessage {
             time = -1;
         services = readUint64();
         byte[] addrBytes = readBytes(16);
+        AddressChecker addrChecker = new AddressChecker();
         try {
             addr = InetAddress.getByAddress(addrBytes);
+            
+            if( addrChecker.IsOnionCatTor( addr )) {
+                hostname = OnionCat.IPV6BytesToOnionHost( addr.getAddress() );
+            }
         } catch (UnknownHostException e) {
             throw new RuntimeException(e);  // Cannot happen.
         }
@@ -236,24 +273,20 @@ public class PeerAddress extends ChildMessage {
         if (hostname != null) {
             return "[" + hostname + "]:" + port;
         }
-        return "[" + addr.getHostAddress() + "]:" + port;
+        if(addr != null ) {
+            return "[" + addr.getHostAddress() + "]:" + port;
+        }
+        return "[]";
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        PeerAddress other = (PeerAddress) o;
-        return other.addr.equals(addr) &&
-                other.port == port &&
-                other.services.equals(services) &&
-                other.time == time;
-        //TODO: including services and time could cause same peer to be added multiple times in collections
+        return o.toString().equals(this.toString());
     }
 
     @Override
     public int hashCode() {
-        return addr.hashCode() ^ port ^ (int) time ^ services.hashCode();
+        return Objects.hashCode(this.toString());
     }
     
     public InetSocketAddress toSocketAddress() {
@@ -263,5 +296,6 @@ public class PeerAddress extends ChildMessage {
         } else {
             return new InetSocketAddress(addr, port);
         }
-    }
+    }   
+
 }

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -39,6 +39,7 @@ public class PeerAddress extends ChildMessage {
     static final int MESSAGE_SIZE = 30;
 
     private InetAddress addr;
+    private String hostname; // Used for .onion addresses
     private int port;
     private BigInteger services;
     private long time;
@@ -96,8 +97,20 @@ public class PeerAddress extends ChildMessage {
         this(addr, MainNetParams.get().getPort());
     }
 
+    /**
+     * Constructs a peer address from an {@link InetSocketAddress}. An InetSocketAddress can take in as parameters an
+     * InetAddress or a String hostname. If you want to connect to a .onion, set the hostname to the .onion address.
+     */
     public PeerAddress(InetSocketAddress addr) {
-        this(addr.getAddress(), addr.getPort());
+        if (addr.getHostName() == null || !addr.getHostName().toLowerCase().endsWith(".onion")) {
+            this.addr = checkNotNull(addr.getAddress());
+        } else {
+            this.hostname = addr.getHostName();
+        }
+        this.port = addr.getPort();
+        this.protocolVersion = NetworkParameters.PROTOCOL_VERSION;
+        this.services = BigInteger.ZERO;
+        length = protocolVersion > 31402 ? MESSAGE_SIZE : MESSAGE_SIZE - 4;
     }
 
     public static PeerAddress localhost(NetworkParameters params) {
@@ -162,6 +175,11 @@ public class PeerAddress extends ChildMessage {
         return length;
     }
 
+    public String getHostname() {
+        maybeParse();
+        return hostname;
+    }
+
     public InetAddress getAddr() {
         maybeParse();
         return addr;
@@ -215,6 +233,9 @@ public class PeerAddress extends ChildMessage {
 
     @Override
     public String toString() {
+        if (hostname != null) {
+            return "[" + hostname + "]:" + port;
+        }
         return "[" + addr.getHostAddress() + "]:" + port;
     }
 
@@ -236,6 +257,11 @@ public class PeerAddress extends ChildMessage {
     }
     
     public InetSocketAddress toSocketAddress() {
-        return new InetSocketAddress(addr, port);
+        // Reconstruct the InetSocketAddress properly
+        if (hostname != null) {
+            return InetSocketAddress.createUnresolved(hostname, port);
+        } else {
+            return new InetSocketAddress(addr, port);
+        }
     }
 }

--- a/core/src/main/java/org/bitcoinj/net/AddressChecker.java
+++ b/core/src/main/java/org/bitcoinj/net/AddressChecker.java
@@ -1,0 +1,72 @@
+package org.bitcoinj.net;
+
+import org.bitcoinj.utils.CIDRUtils;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Created by danda on 1/12/17.
+ */
+public class AddressChecker {
+
+    private CIDRUtils onionCatNet;
+    private CIDRUtils rfc4193Net;
+
+    public AddressChecker() {
+
+        // Note:  this is borrowed/ported from btcd (written in go).
+
+        // btcd has many more rules that are probably important and should be
+        // implemented in this class, but for now we only care about onion
+        // addresses for onioncat (ipv6) encoding/decoding.
+
+        // onionCatNet defines the IPv6 address block used to support Tor.
+        // bitcoind encodes a .onion address as a 16 byte number by decoding the
+        // address prior to the .onion (i.e. the key hash) base32 into a ten
+        // byte number. It then stores the first 6 bytes of the address as
+        // 0xfd, 0x87, 0xd8, 0x7e, 0xeb, 0x43.
+        //
+        // This is the same range used by OnionCat, which is part part of the
+        // RFC4193 unique local IPv6 range.
+        //
+        // In summary the format is:
+        // { magic 6 bytes, 10 bytes base32 decode of key hash }
+        onionCatNet = new CIDRUtils("fd87:d87e:eb43::", 48);
+
+        // rfc4193Net specifies the IPv6 unique local address block as defined
+        // by RFC4193 (FC00::/7).
+        rfc4193Net = new CIDRUtils("FC00::", 7);
+    }
+
+    // IsValid returns whether or not the passed address is valid.  The address is
+    // considered invalid under the following circumstances:
+    // IPv4: It is either a zero or all bits set address.
+    // IPv6: It is either a zero or RFC3849 documentation address.
+    public boolean IsValid(InetAddress addr) {
+        // todo:  port/implement.
+
+        // IsUnspecified returns if address is 0, so only all bits set, and
+        // RFC3849 need to be explicitly checked.
+
+        // return na.IP != nil && !(na.IP.IsUnspecified() ||
+        //    na.IP.Equal(net.IPv4bcast))
+
+        return true;
+    }
+
+    // IsOnionCatTor returns whether or not the passed address is in the IPv6 range
+    // used by bitcoin to support Tor (fd87:d87e:eb43::/48).  Note that this range
+    // is the same range used by OnionCat, which is part of the RFC4193 unique local
+    // IPv6 range.
+    public boolean IsOnionCatTor(InetAddress addr) {
+        return onionCatNet.isInRange(addr);
+    }
+
+    // IsRFC4193 returns whether or not the passed address is part of the IPv6
+    // unique local range as defined by RFC4193 (FC00::/7).
+    public boolean IsRFC4193(InetAddress addr) {
+        return rfc4193Net.isInRange(addr);
+    }
+
+}

--- a/core/src/main/java/org/bitcoinj/net/BlockingClient.java
+++ b/core/src/main/java/org/bitcoinj/net/BlockingClient.java
@@ -100,7 +100,7 @@ public class BlockingClient implements MessageWriteTarget {
                     }
                 } catch (Exception e) {
                     if (!vCloseRequested) {
-                        log.error("Error trying to open/read from connection: {}: {}", serverAddress, e.getMessage());
+                        log.debug("Error trying to open/read from connection: {}: {}", serverAddress, e.getMessage());
                         connectFuture.setException(e);
                     }
                 } finally {

--- a/core/src/main/java/org/bitcoinj/net/OnionCat.java
+++ b/core/src/main/java/org/bitcoinj/net/OnionCat.java
@@ -1,0 +1,53 @@
+package org.bitcoinj.net;
+
+import org.bitcoinj.utils.Base32;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+
+/**
+ * Created by danda on 1/12/17.
+ */
+public class OnionCat {
+
+    /** Converts a .onion address to onioncat format
+     *
+     * @param hostname
+     * @return
+     */
+    public static byte[] onionHostToIPV6Bytes(String hostname) {
+        String needle = ".onion";
+        if( hostname.endsWith(needle) ) {
+            hostname = hostname.substring(0,hostname.length() - needle.length());
+        }
+        byte[] prefix = new byte[] {(byte)0xfd, (byte)0x87, (byte)0xd8, (byte)0x7e, (byte)0xeb, (byte)0x43};
+        byte[] onionaddr = Base32.base32Decode(hostname);
+        byte[] ipBytes = new byte[prefix.length + onionaddr.length];
+        System.arraycopy(prefix, 0, ipBytes, 0, prefix.length);
+        System.arraycopy(onionaddr, 0, ipBytes, prefix.length, onionaddr.length);
+
+        return ipBytes;
+    }
+
+    public static InetAddress onionHostToInetAddress(String hostname) throws UnknownHostException {
+        return InetAddress.getByAddress(onionHostToIPV6Bytes(hostname));
+    }
+
+    public static InetSocketAddress onionHostToInetSocketAddress(String hostname, int port) throws UnknownHostException {
+        return new InetSocketAddress( onionHostToInetAddress(hostname), port);
+    }
+
+
+    /** Converts an IPV6 onioncat encoded address to a hostname
+     *
+     * @param bytes
+     * @return
+     */
+    public static String IPV6BytesToOnionHost( byte[] bytes) {
+        String base32 = Base32.base32Encode( Arrays.copyOfRange(bytes, 6, 16) );
+        return base32.toLowerCase() + ".onion";
+    }
+}

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -60,11 +60,13 @@ public class MainNetParams extends AbstractBitcoinNetParams {
         checkpoints.put(200000, Sha256Hash.wrap("000000000000034a7dedef4a161fa058a2d67a173a90155f3a2fe6fc132e0ebf"));
 
         dnsSeeds = new String[] {
-                "seed.bitcoin.sipa.be",        // Pieter Wuille
-                "dnsseed.bluematt.me",         // Matt Corallo
-                "dnsseed.bitcoin.dashjr.org",  // Luke Dashjr
-                "seed.bitcoinstats.com",       // Chris Decker
-                "seed.bitnodes.io",            // Addy Yeow
+                "seed.bitcoin.sipa.be",          // Pieter Wuille
+                "dnsseed.bluematt.me",           // Matt Corallo
+                "dnsseed.bitcoin.dashjr.org",    // Luke Dashjr
+                "seed.bitcoinstats.com",         // Chris Decker
+                "bitseed.xf2.org",               // Jeff Garzik
+                "seed.bitcoin.jonasschnelli.ch", // Jonas Schnelli
+                "seed.bitnodes.io",              // Addy Yeow
         };
 
         addrSeeds = new int[] {

--- a/core/src/main/java/org/bitcoinj/utils/Base32.java
+++ b/core/src/main/java/org/bitcoinj/utils/Base32.java
@@ -1,0 +1,90 @@
+// Copied from orchid Tor lib.
+
+package org.bitcoinj.utils;
+
+import com.subgraph.orchid.TorException;
+
+public class Base32 {
+	private final static String BASE32_CHARS = "abcdefghijklmnopqrstuvwxyz234567";
+	
+	public static String base32Encode(byte[] source) {
+		return base32Encode(source, 0, source.length);
+	}
+	
+	public static String base32Encode(byte[] source, int offset, int length) {
+		final int nbits = length * 8;
+		if(nbits % 5 != 0) 
+			throw new TorException("Base32 input length must be a multiple of 5 bits");
+		
+		final int outlen = nbits / 5;
+		final StringBuffer outbuffer = new StringBuffer();
+		int bit = 0;
+		for(int i = 0; i < outlen; i++) {
+			int v = (source[bit / 8] & 0xFF) << 8;
+			if(bit + 5 < nbits) v += (source[bit / 8 + 1] & 0xFF);
+			int u = (v >> (11 - (bit % 8))) & 0x1F;
+			outbuffer.append(BASE32_CHARS.charAt(u));
+			bit += 5;
+		}		
+		return outbuffer.toString();
+	}
+	
+	public static byte[] base32Decode(String source) {
+		int[] v = stringToIntVector(source);
+		
+		int nbits = source.length() * 5;
+		if(nbits % 8 != 0) 
+			throw new TorException("Base32 decoded array must be a muliple of 8 bits");
+		
+		int outlen = nbits / 8;
+		byte[] outbytes = new byte[outlen];
+		
+		int bit = 0;
+		for(int i = 0; i < outlen; i++) {
+			int bb = bit / 5;
+			outbytes[i] = (byte) decodeByte(bit, v[bb], v[bb + 1], v[bb + 2]);
+			bit += 8;	
+		}
+		return outbytes;
+	}
+	
+	private static int decodeByte(int bitOffset, int b0, int b1, int b2) {
+		switch(bitOffset % 40) {
+		case 0: 
+			return ls(b0, 3) + rs(b1, 2);
+		case 8:
+			return ls(b0, 6) + ls(b1, 1) + rs (b2, 4);
+		case 16:
+			return ls(b0, 4) + rs(b1, 1);
+		case 24:
+			return ls(b0, 7) + ls(b1, 2) + rs(b2, 3);
+		case 32:
+			return ls(b0, 5) + (b1 & 0xFF);
+		}
+		throw new TorException("Illegal bit offset");
+	}
+	
+	private static int ls(int n, int shift) {
+		return ((n << shift) & 0xFF);
+	}
+	
+	private static int rs(int n, int shift) {
+		return ((n >> shift) & 0xFF);
+	}
+	
+	private static int[] stringToIntVector(String s) {
+		final int[] ints = new int[s.length() + 1];
+		for(int i = 0; i < s.length(); i++) {
+			int b = s.charAt(i) & 0xFF;
+			if(b > 0x60 && b < 0x7B)
+				ints[i] = b - 0x61;
+			else if(b > 0x31 && b < 0x38) 
+				ints[i] = b - 0x18;
+			else if(b > 0x40 && b < 0x5B) 
+				ints[i] = b - 0x41;
+			else
+				throw new TorException("Illegal character in base32 encoded string: "+ s.charAt(i));
+		}
+		return ints;
+	}
+}

--- a/core/src/main/java/org/bitcoinj/utils/CIDRUtils.java
+++ b/core/src/main/java/org/bitcoinj/utils/CIDRUtils.java
@@ -1,0 +1,156 @@
+// adapted from https://github.com/edazdarevic/CIDRUtils/
+/*
+* The MIT License
+*
+* Copyright (c) 2013 Edin Dazdarevic (edin.dazdarevic@gmail.com)
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+* */
+
+package org.bitcoinj.utils;
+
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A class that enables to get an IP range from CIDR specification. It supports
+ * both IPv4 and IPv6.
+ */
+public class CIDRUtils {
+
+    private InetAddress inetAddress;
+    private InetAddress startAddress;
+    private InetAddress endAddress;
+    private final int prefixLength;
+
+
+    public CIDRUtils(String cidr) {
+
+        try {
+            /* split CIDR to address and prefix part */
+            if (cidr.contains("/")) {
+                int index = cidr.indexOf("/");
+                String addressPart = cidr.substring(0, index);
+                String networkPart = cidr.substring(index + 1);
+    
+                inetAddress = InetAddress.getByName(addressPart);
+                prefixLength = Integer.parseInt(networkPart);
+    
+                calculate();
+            } else {
+                throw new IllegalArgumentException("not an valid CIDR format!");
+            }
+        } catch (UnknownHostException e) {
+            // note: no dns lookup is performed in try because these are numeric addresses.
+            throw new RuntimeException(e);  // Cannot happen.
+        }        
+    }
+
+    public CIDRUtils(String addr, Integer prefixLength) {
+
+        try {
+            inetAddress = InetAddress.getByName(addr);
+            this.prefixLength = prefixLength;
+    
+            calculate();
+        } catch (UnknownHostException e) {
+            // note: no dns lookup is performed in try because these are numeric addresses.
+            throw new RuntimeException(e);  // Cannot happen.
+        }        
+    }
+
+    private void calculate() throws UnknownHostException {
+
+        ByteBuffer maskBuffer;
+        int targetSize;
+        if (inetAddress.getAddress().length == 4) {
+            maskBuffer =
+                    ByteBuffer
+                            .allocate(4)
+                            .putInt(-1);
+            targetSize = 4;
+        } else {
+            maskBuffer = ByteBuffer.allocate(16)
+                    .putLong(-1L)
+                    .putLong(-1L);
+            targetSize = 16;
+        }
+
+        BigInteger mask = (new BigInteger(1, maskBuffer.array())).not().shiftRight(prefixLength);
+
+        BigInteger ipVal = new BigInteger(1, inetAddress.getAddress());
+
+        BigInteger startIp = ipVal.and(mask);
+        BigInteger endIp = startIp.add(mask.not());
+
+        byte[] startIpArr = toBytes(startIp.toByteArray(), targetSize);
+        byte[] endIpArr = toBytes(endIp.toByteArray(), targetSize);
+
+        this.startAddress = InetAddress.getByAddress(startIpArr);
+        this.endAddress = InetAddress.getByAddress(endIpArr);
+
+    }
+
+    private byte[] toBytes(byte[] array, int targetSize) {
+        int counter = 0;
+        List<Byte> newArr = new ArrayList<Byte>();
+        while (counter < targetSize && (array.length - 1 - counter >= 0)) {
+            newArr.add(0, array[array.length - 1 - counter]);
+            counter++;
+        }
+
+        int size = newArr.size();
+        for (int i = 0; i < (targetSize - size); i++) {
+
+            newArr.add(0, (byte) 0);
+        }
+
+        byte[] ret = new byte[newArr.size()];
+        for (int i = 0; i < newArr.size(); i++) {
+            ret[i] = newArr.get(i);
+        }
+        return ret;
+    }
+
+    public String getNetworkAddress() {
+
+        return this.startAddress.getHostAddress();
+    }
+
+    public String getBroadcastAddress() {
+        return this.endAddress.getHostAddress();
+    }
+
+    public boolean isInRange(InetAddress address) {
+        BigInteger start = new BigInteger(1, this.startAddress.getAddress());
+        BigInteger end = new BigInteger(1, this.endAddress.getAddress());
+        BigInteger target = new BigInteger(1, address.getAddress());
+
+        int st = start.compareTo(target);
+        int te = target.compareTo(end);
+
+        return (st == -1 || st == 0) && (te == -1 || te == 0);
+    }    
+    
+    public boolean isInRange(String ipAddress) throws UnknownHostException {
+        return isInRange(InetAddress.getByName(ipAddress));
+    }
+}

--- a/examples/src/main/javascript/tor.js
+++ b/examples/src/main/javascript/tor.js
@@ -6,19 +6,15 @@ var params = bcj.params.MainNetParams.get();
 var context = new bcj.core.Context(params);
 bcj.utils.BriefLogFormatter.init();
 
-var InetAddress = Java.type("java.net.InetAddress");
+var PeerAddress = Java.type("org.bitcoinj.core.PeerAddress");
 var InetSocketAddress = Java.type("java.net.InetSocketAddress");
 
-// Hack around the fact that PeerAddress assumes nodes have IP addresses. Simple enough for now.
-var OnionAddress = Java.extend(Java.type("org.bitcoinj.core.PeerAddress"), {
-    toSocketAddress: function() {
-        return InetSocketAddress.createUnresolved("hhiv5pnxenvbf4am.onion", params.port);
-    }
-});
+// The PeerAddress class can now handle InetSocketAddresses with hostnames if they are .onion.
+var OnionAddress = InetSocketAddress.createUnresolved("hhiv5pnxenvbf4am.onion", params.port);
 
 var pg = bcj.core.PeerGroup.newWithTor(context, null, new com.subgraph.orchid.TorClient(), false);
-// c'tor is bogus here: the passed in InetAddress will be ignored.
-pg.addAddress(new OnionAddress(InetAddress.localHost, params.port));
+
+pg.addAddress(new PeerAddress(OnionAddress));
 pg.start();
 
 pg.waitForPeers(1).get();
@@ -28,6 +24,5 @@ for each (var peer in pg.connectedPeers) {
     print(peer.peerVersionMessage.subVer);
     peer.ping().get()
 }
-
 
 pg.stop();


### PR DESCRIPTION
This pull request supports connecting to bitcoin nodes operating as tor hidden services (.onion).

Another change is that it now listens for the "addr" bitcoin message from peers and discovers new nodes to connect to that way.

bitcoin-core and other clients encode .onion addresses inside ipv6 using the "onioncat" format, which is a specially prefixed ipv6 address.  This patch detects these .onion addresses and is able to add and connect to them.

