### PR TITLE
Add missing HASH160 checking to `Script.correctlySpends()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/internal/CryptoUtils.java
+++ b/core/src/main/java/org/bitcoinj/crypto/internal/CryptoUtils.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.bitcoinj.crypto.internal;
+
+import org.bitcoinj.core.Sha256Hash;
+import org.bouncycastle.crypto.digests.RIPEMD160Digest;
+
+// Methods taken from BitcoinJ main branch
+public class CryptoUtils {
+    /**
+     * Calculate RIPEMD160(SHA256(input)). This is used in Address calculations.
+     * @param input bytes to hash
+     * @return RIPEMD160(SHA256(input))
+     */
+    public static byte[] sha256hash160(byte[] input) {
+        byte[] sha256 = Sha256Hash.hash(input);
+        return digestRipeMd160(sha256);
+    }
+
+    /**
+     * Calculate RIPEMD160(input).
+     * @param input bytes to hash
+     * @return RIPEMD160(input)
+     */
+    public static byte[] digestRipeMd160(byte[] input) {
+        RIPEMD160Digest digest = new RIPEMD160Digest();
+        digest.update(input, 0, input.length);
+        byte[] ripemdHash = new byte[20];
+        digest.doFinal(ripemdHash, 0);
+        return ripemdHash;
+    }
+}

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -22,6 +22,7 @@ package org.bitcoinj.script;
 import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.TransactionSignature;
 import com.google.common.collect.Lists;
+import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.bouncycastle.crypto.digests.RIPEMD160Digest;
@@ -1568,7 +1569,14 @@ public class Script {
                 throw new ScriptException(ScriptError.SCRIPT_ERR_SIG_DER, "Cannot decode", x);
             }
             ECKey pubkey = ECKey.fromPublicOnly(witness.getPush(1));
-            Script scriptCode = ScriptBuilder.createP2PKHOutputScript(pubkey);
+
+            byte[] requiredHash160 = ScriptPattern.extractHashFromP2WH(scriptPubKey);
+            byte[] providedHash160 = CryptoUtils.sha256hash160(pubkey.getPubKey());
+            if (!Arrays.equals(requiredHash160, providedHash160)) {
+                throw new ScriptException(ScriptError.SCRIPT_ERR_EQUALVERIFY, "Invalid pubkey hash");
+            }
+            Script scriptCode = ScriptBuilder.createP2PKHOutputScript(requiredHash160);
+
             Sha256Hash sigHash = txContainingThis.hashForWitnessSignature(scriptSigIndex, scriptCode, value,
                     signature.sigHashMode(), false);
             boolean validSig = pubkey.verify(sigHash, signature);


### PR DESCRIPTION
Backport a fix on the upstream master branch https://github.com/bitcoinj/bitcoinj/commit/b575a682acf614b9ff95cacbdeb48f86c3ababe0 to the security advisory https://github.com/bitcoinj/bitcoinj/security/advisories/GHSA-hfcf-v2f8-x9pc concerning two fast-path verification bugs for standard P2PKH and native P2WPKH spends in `org.bitcoinj.script.ScriptExecution.correctlySpends()`, whereby the method fails to verify that the public key is the one committed to by the output being spent. As a result, any attacker keypair can satisfy bitcoinj's local verification for arbitrary P2PKH and P2WPKH outputs.

Only the latter (P2WPKH) fast path is present in our old version of the method, so port the missing
```
HASH160(pubkey) == ScriptPattern.extractHashFromP2WH(scriptPubKey)
```
check to that code branch only.

Also partially port the missing `org.bitcoinj.crypto.internal.CryptoUtils` class from the upstream branch, needed to support the HASH160 calculation.
